### PR TITLE
#7 자동 로그인

### DIFF
--- a/data/src/main/java/com/mashup/data/datasource/local/LocalLoginDataSource.kt
+++ b/data/src/main/java/com/mashup/data/datasource/local/LocalLoginDataSource.kt
@@ -1,11 +1,15 @@
 package com.mashup.data.datasource.local
 
+import android.app.Application
+import android.content.Context
 import android.content.SharedPreferences
 import javax.inject.Inject
 
 class LocalLoginDataSource @Inject constructor(
-    private val preferences: SharedPreferences,
+    application: Application
 ) {
+    private val preferences: SharedPreferences = application.getSharedPreferences(LOGIN_PREF, Context.MODE_PRIVATE)
+
     fun getJwt() = preferences.getString(JWT, "") ?: ""
 
     fun setJwt(jwt: String) {
@@ -14,5 +18,6 @@ class LocalLoginDataSource @Inject constructor(
 
     companion object {
         const val JWT = "JWT"
+        const val LOGIN_PREF = "LOGIN_PREF"
     }
 }

--- a/data/src/main/java/com/mashup/data/datasource/local/LocalLoginDataSource.kt
+++ b/data/src/main/java/com/mashup/data/datasource/local/LocalLoginDataSource.kt
@@ -1,0 +1,18 @@
+package com.mashup.data.datasource.local
+
+import android.content.SharedPreferences
+import javax.inject.Inject
+
+class LocalLoginDataSource @Inject constructor(
+    private val preferences: SharedPreferences,
+) {
+    fun getJwt() = preferences.getString(JWT, "") ?: ""
+
+    fun setJwt(jwt: String) {
+        preferences.edit().putString(JWT, jwt).apply()
+    }
+
+    companion object {
+        const val JWT = "JWT"
+    }
+}

--- a/data/src/main/java/com/mashup/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/mashup/data/di/RepositoryModule.kt
@@ -1,7 +1,9 @@
 package com.mashup.data.di
 
 import com.mashup.data.repository.GithubRepository
+import com.mashup.data.repository.LoginRepository
 import com.mashup.data.repository.impl.GithubRepositoryImpl
+import com.mashup.data.repository.impl.LoginRepositoryImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -14,4 +16,8 @@ interface RepositoryModule {
     @Binds
     @Singleton
     fun bindGithubRepository(githubRepositoryImpl: GithubRepositoryImpl): GithubRepository
+
+    @Binds
+    @Singleton
+    fun bindLoginRepository(loginRepositoryImpl: LoginRepositoryImpl): LoginRepository
 }

--- a/data/src/main/java/com/mashup/data/repository/LoginRepository.kt
+++ b/data/src/main/java/com/mashup/data/repository/LoginRepository.kt
@@ -1,0 +1,6 @@
+package com.mashup.data.repository
+
+interface LoginRepository {
+    fun setJwt(jwt: String)
+    fun getJwt(): String
+}

--- a/data/src/main/java/com/mashup/data/repository/impl/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/data/repository/impl/LoginRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.mashup.data.repository.impl
+
+import com.mashup.data.datasource.local.LocalLoginDataSource
+import com.mashup.data.repository.LoginRepository
+import javax.inject.Inject
+
+class LoginRepositoryImpl @Inject constructor(
+    private val localLoginDataSource: LocalLoginDataSource
+) : LoginRepository {
+    override fun setJwt(jwt: String) {
+        localLoginDataSource.setJwt(jwt)
+    }
+
+    override fun getJwt() = localLoginDataSource.getJwt()
+}

--- a/domain/src/main/java/com/mashup/domain/di/UseCaseModule.kt
+++ b/domain/src/main/java/com/mashup/domain/di/UseCaseModule.kt
@@ -1,7 +1,9 @@
 package com.mashup.domain.di
 
 import com.mashup.domain.usecase.GetUserUrlUseCase
+import com.mashup.domain.usecase.IsAlreadyLoginUseCase
 import com.mashup.domain.usecase.impl.GetUserUrlUseCaseImpl
+import com.mashup.domain.usecase.impl.IsAlreadyLoginUseCaseImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -12,4 +14,7 @@ import dagger.hilt.android.components.ActivityRetainedComponent
 interface UseCaseModule {
     @Binds
     fun bindGetUserUrlUseCase(useCaseImpl: GetUserUrlUseCaseImpl): GetUserUrlUseCase
+
+    @Binds
+    fun bindIsAlreadyLoginUseCase(isAlreadyLoginUseCaseImpl: IsAlreadyLoginUseCaseImpl): IsAlreadyLoginUseCase
 }

--- a/domain/src/main/java/com/mashup/domain/usecase/IsAlreadyLoginUseCase.kt
+++ b/domain/src/main/java/com/mashup/domain/usecase/IsAlreadyLoginUseCase.kt
@@ -1,0 +1,5 @@
+package com.mashup.domain.usecase
+
+interface IsAlreadyLoginUseCase {
+    suspend operator fun invoke(): Boolean
+}

--- a/domain/src/main/java/com/mashup/domain/usecase/impl/IsAlreadyLoginUseCaseImpl.kt
+++ b/domain/src/main/java/com/mashup/domain/usecase/impl/IsAlreadyLoginUseCaseImpl.kt
@@ -1,0 +1,11 @@
+package com.mashup.domain.usecase.impl
+
+import com.mashup.data.repository.LoginRepository
+import com.mashup.domain.usecase.IsAlreadyLoginUseCase
+import javax.inject.Inject
+
+class IsAlreadyLoginUseCaseImpl @Inject constructor(
+    private val loginRepository: LoginRepository,
+): IsAlreadyLoginUseCase {
+    override suspend fun invoke(): Boolean = loginRepository.getJwt().isBlank().not()
+}


### PR DESCRIPTION
### 요약 
이미 로그인했던 유저인지 확인한다.

로그인을 한 번이라도 했다면 jwt를 sharedPreferences에 저장
그리고 jwt가 sharedPreferences가 저장되어져있다면 IsAlreadyUseCase를 통해 true를 반환

### 특이사항
* 로직만 만들어놓고 실제로 액티비티의 이동을 담진 않았음 // 액티비티가 생성되면 만들게연
* 현재 jwt를 서버에서 받아오지 않고 있기 때문에 jwt를 저장하는 usecase는 만들지 않았음
* sharedPreferences를 일단은 datasource안에 넣어두고 application을 inject 했습니당.. 
ㄴapplication을 inject 하지 않고 앱모듈에서 sharedPreferences를 둘 수 있는 방법이 있다던지.. 등등.. 좋은 의견 있으면 주세염....