### PR TITLE
feat: #43 질문지 구성 페이지 윗쪽 헤더 UI 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,6 +51,7 @@
         <activity android:name="com.mashup.presenter.set_group.SetGroupActivity"/>
         <activity android:name="com.mashup.presenter.add_friend.AddFriendActivity" />
         <activity android:name="com.mashup.presenter.reply_preference.ReplyPreferenceActivity" />
+        <activity android:name="com.mashup.presenter.send_preference.SendPreferenceActivity" />
     </application>
 
 </manifest>

--- a/presenter/src/main/java/com/mashup/presenter/dev/BridgeActivity.kt
+++ b/presenter/src/main/java/com/mashup/presenter/dev/BridgeActivity.kt
@@ -13,6 +13,7 @@ import com.mashup.presenter.main.MainActivity
 import com.mashup.presenter.receive_alarm.ReceiveAlarmActivity
 import com.mashup.presenter.reply_preference.ReplyPreferenceActivity
 import com.mashup.presenter.room_test.RoomTestActivity
+import com.mashup.presenter.send_preference.SendPreferenceActivity
 import com.mashup.presenter.set_group.SetGroupActivity
 import com.mashup.presenter.ui.theme.ChinchinTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -40,6 +41,7 @@ class BridgeActivity : ComponentActivity() {
                             SetGroupActivity::class.java,
                             AddFriendActivity::class.java,
                             ReplyPreferenceActivity::class.java,
+                            SendPreferenceActivity::class.java,
                         )
                     )
                 }

--- a/presenter/src/main/java/com/mashup/presenter/send_preference/SendPreferenceActivity.kt
+++ b/presenter/src/main/java/com/mashup/presenter/send_preference/SendPreferenceActivity.kt
@@ -1,0 +1,63 @@
+package com.mashup.presenter.send_preference
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.mashup.presenter.friend_detail.model.QuestionUiModel
+import com.mashup.presenter.ui.common.ChinChinToolbar
+import com.mashup.presenter.ui.send_questions.QuestionCategoryList
+import com.mashup.presenter.ui.send_questions.SendPreferenceQuestionList
+import com.mashup.presenter.ui.send_questions.SendPreferenceQuestionTitle
+import com.mashup.presenter.ui.theme.ChinchinTheme
+import com.mashup.presenter.ui.theme.Gray_600
+
+class SendPreferenceActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ChinchinTheme {
+                CreateQuestionSheetScreen(
+                    categories = listOf("취향 키워드", "개인정보", "자유질문")
+                ) {
+                    finish()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun CreateQuestionSheetScreen(
+    categories: List<String> = listOf(),
+    questions: List<QuestionUiModel> = listOf(),
+    userName: String = "윤혜",
+    onBackButtonClick: () -> Unit = {},
+) {
+    Column {
+        ChinChinToolbar(title = "취향 질문 보내기") { // TODO: isActiveConfirmButton추가된 ChinChinToolBar 받아서 완료버튼 추가
+            onBackButtonClick()
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Column(modifier = Modifier.padding(horizontal = 24.dp)) {
+            SendPreferenceQuestionTitle(userName)
+            Text(
+                text = "아래 키워드를 선택해 질문을 구성할 수 있습니다.",
+                color = Gray_600,
+                fontSize = 12.sp,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+            QuestionCategoryList(categories)
+            Spacer(modifier = Modifier.height(13.dp))
+            SendPreferenceQuestionList(
+                questions = questions,
+            )
+        }
+    }
+}

--- a/presenter/src/main/java/com/mashup/presenter/ui/send_questions/SendPreferenceComponent.kt
+++ b/presenter/src/main/java/com/mashup/presenter/ui/send_questions/SendPreferenceComponent.kt
@@ -1,0 +1,111 @@
+package com.mashup.presenter.ui.send_questions
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Icon
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.mashup.presenter.R
+import com.mashup.presenter.friend_detail.model.QuestionUiModel
+import com.mashup.presenter.ui.theme.Gray_500
+import com.mashup.presenter.ui.theme.Gray_800
+
+@Composable
+fun SendPreferenceQuestionTitle(userName: String) {
+    Column {
+        Row {
+            Text(
+                text = userName,
+                color = Gray_800,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text = "에게 물어볼",
+                color = Gray_500,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(start = 4.dp)
+            )
+        }
+        Row(modifier = Modifier.padding(top = 2.dp)) {
+            Text(
+                text = "키워드를 선택",
+                color = Gray_800,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text = "해주세요!",
+                color = Gray_500,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }
+}
+
+@Composable
+fun QuestionCategoryList(categories: List<String>) { // TODO: Category UiModel 생성 후 변경
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        items(categories) { category ->
+            QuestionCategoryChip(category = category)
+        }
+    }
+}
+
+@Composable
+fun QuestionCategoryChip(category: String, onDialogOpen: (String) -> Unit = {}) {
+    OutlinedButton(
+        onClick = { onDialogOpen(category) },
+        shape = RoundedCornerShape(16.dp),
+        border = ButtonDefaults.outlinedBorder.copy(brush = SolidColor(Gray_500)),
+        modifier = Modifier
+            .defaultMinSize(minWidth = 1.dp, minHeight = 1.dp)
+            .wrapContentWidth()
+            .height(32.dp),
+        elevation = ButtonDefaults.elevation(
+            defaultElevation = 0.dp,
+            pressedElevation = 0.dp,
+        ),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_chip),
+                contentDescription = "chip icons",
+                tint = Gray_500
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = category,
+                color = Color.White,
+                fontSize = 14.sp,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Composable
+fun SendPreferenceQuestionList(
+    questions: List<QuestionUiModel> = listOf()
+) {
+    // TODO: ChinChinQuestionCard로 구성하기
+}

--- a/presenter/src/main/res/drawable/ic_chip.xml
+++ b/presenter/src/main/res/drawable/ic_chip.xml
@@ -1,0 +1,34 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M11,6.267L5,2.807"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#757575"
+      android:strokeLineCap="round"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M14,10.666V5.333C14,5.099 13.938,4.87 13.821,4.667C13.704,4.465 13.536,4.297 13.333,4.18L8.667,1.513C8.464,1.396 8.234,1.334 8,1.334C7.766,1.334 7.536,1.396 7.333,1.513L2.667,4.18C2.464,4.297 2.296,4.465 2.179,4.667C2.062,4.87 2,5.099 2,5.333V10.666C2,10.9 2.062,11.13 2.179,11.332C2.296,11.535 2.464,11.703 2.667,11.82L7.333,14.486C7.536,14.604 7.766,14.665 8,14.665C8.234,14.665 8.464,14.604 8.667,14.486L13.333,11.82C13.536,11.703 13.704,11.535 13.821,11.332C13.938,11.13 14,10.9 14,10.666Z"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#757575"
+      android:strokeLineCap="round"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M2.18,4.64L8,8.007L13.82,4.64"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#757575"
+      android:strokeLineCap="round"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M8,14.72V8"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#757575"
+      android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
- 질문지 윗쪽 헤더 구현

### TODO
- 경무오빠 PR머지된 후 ChinChinToolBar, ChinChinCard를 사용해야함.
- Chip 버튼의 verticalCenter 정렬이 안맞는데, 찾아보니 fontMargin이 있는 것 같음.[(참고)](https://stackoverflow.com/questions/66126551/jetpack-compose-centering-text-without-font-padding) 혹시 해결해본 적 있으면 말해주세요! 참고자료에서는`includeFontPadding = false`로 줘야하는 것 같은데 요부분 compose 버전 [1.2.0-alpha05](https://developer.android.com/jetpack/androidx/releases/compose-ui#1.2.0-alpha05)에서 해결되어서 업 해야해서 의견 주시면 좋을 것 같아요. 
<img width="584" alt="스크린샷 2022-07-26 오전 12 10 29" src="https://user-images.githubusercontent.com/37477660/180814056-e994737e-cb40-4356-8e98-53fec764138e.png">
