### PR TITLE
#150 메인 썸네일 이미지 안나오는 이슈 및 친구 프로필 화면 groupName 대응

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_chinchin"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/Theme.Chinchin">
         <activity
             android:name="com.mashup.chinchin.presenter.dev.BridgeActivity"

--- a/data/src/main/java/com/mashup/chinchin/data/datasource/remote/RemoteFriendDataSource.kt
+++ b/data/src/main/java/com/mashup/chinchin/data/datasource/remote/RemoteFriendDataSource.kt
@@ -24,7 +24,7 @@ class RemoteFriendDataSource @Inject constructor(
         return chinChinService.addFriend(addFriendRequestBody)
     }
 
-    suspend fun updateFriend(updateFriendRequestBody: UpdateFriendRequestBody): UpdateFriendResponseBody {
-        return chinChinService.updateFriend(updateFriendRequestBody)
+    suspend fun updateFriend(friendId: Long, updateFriendRequestBody: UpdateFriendRequestBody): UpdateFriendResponseBody {
+        return chinChinService.updateFriend(friendId, updateFriendRequestBody)
     }
 }

--- a/data/src/main/java/com/mashup/chinchin/data/dto/remote/responsebody/common/ProfileResponse.kt
+++ b/data/src/main/java/com/mashup/chinchin/data/dto/remote/responsebody/common/ProfileResponse.kt
@@ -7,6 +7,7 @@ import com.mashup.chinchin.domain.model.Profile
 data class ProfileResponse(
     @SerializedName("id") val id: Long,
     @SerializedName("groupId") val groupId: Long,
+    @SerializedName("groupName") val groupName: String,
     @SerializedName("name") val name: String,
     @SerializedName("dateOfBirth") val dateOfBirth: String,
     @SerializedName("isMember") val isMember: Boolean,
@@ -22,7 +23,7 @@ data class ProfileResponse(
             isMember = isMember,
             thumbnailImageUrl = thumbnailImageUrl,
             kakaoId = kakaoId,
-            groupName = "" // FIXME 은정이가 추가해줄예정
+            groupName = groupName
         )
     }
 }

--- a/data/src/main/java/com/mashup/chinchin/data/repository/FriendRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/chinchin/data/repository/FriendRepositoryImpl.kt
@@ -34,7 +34,7 @@ class FriendRepositoryImpl @Inject constructor(
         return remoteFriendDataSource.addFriend(param).friendId
     }
 
-    override suspend fun updateFriend(friend: UpdateFriendParams): Long {
+    override suspend fun updateFriend(friendId: Long, friend: UpdateFriendParams): Long {
         val param = with(friend) {
             UpdateFriendRequestBody(
                 name = name,
@@ -44,6 +44,6 @@ class FriendRepositoryImpl @Inject constructor(
                 kakaoId = kakaoId
             )
         }
-        return remoteFriendDataSource.updateFriend(param).friendId
+        return remoteFriendDataSource.updateFriend(friendId, param).friendId
     }
 }

--- a/data/src/main/java/com/mashup/chinchin/data/service/ChinChinService.kt
+++ b/data/src/main/java/com/mashup/chinchin/data/service/ChinChinService.kt
@@ -84,6 +84,7 @@ interface ChinChinService {
      */
     @POST("/friend/{friendId}")
     suspend fun updateFriend(
+        @Path("friendId") friendId: Long,
         @Body updateFriendRequestBody: UpdateFriendRequestBody
     ): UpdateFriendResponseBody
 

--- a/domain/src/main/java/com/mashup/chinchin/domain/repository/FriendRepository.kt
+++ b/domain/src/main/java/com/mashup/chinchin/domain/repository/FriendRepository.kt
@@ -9,5 +9,5 @@ interface FriendRepository {
     suspend fun getFriendProfile(friendId: Long): FriendProfile
     suspend fun getFriends(): List<Friend>
     suspend fun addFriend(friend: AddFriendParams): Long
-    suspend fun updateFriend(friend: UpdateFriendParams): Long
+    suspend fun updateFriend(friendId: Long, friend: UpdateFriendParams): Long
 }

--- a/domain/src/main/java/com/mashup/chinchin/domain/usecase/UpdateFriendUseCase.kt
+++ b/domain/src/main/java/com/mashup/chinchin/domain/usecase/UpdateFriendUseCase.kt
@@ -6,8 +6,8 @@ import javax.inject.Inject
 class UpdateFriendUseCase @Inject constructor(
     private val friendRepository: FriendRepository
 ) {
-    suspend operator fun invoke(friend: UpdateFriendParams): Long {
-        return friendRepository.updateFriend(friend)
+    suspend operator fun invoke(friendId: Long, friend: UpdateFriendParams): Long {
+        return friendRepository.updateFriend(friendId, friend)
     }
 }
 

--- a/presenter/src/main/java/com/mashup/chinchin/presenter/friend_information/FriendInformationViewModel.kt
+++ b/presenter/src/main/java/com/mashup/chinchin/presenter/friend_information/FriendInformationViewModel.kt
@@ -7,10 +7,8 @@ import com.mashup.chinchin.domain.usecase.UpdateFriendParams
 import com.mashup.chinchin.domain.usecase.UpdateFriendUseCase
 import com.mashup.chinchin.presenter.friend_information.model.FriendProfileType
 import com.mashup.chinchin.presenter.common.model.FriendUiModel
-import com.mashup.chinchin.presenter.main.model.FriendGroupUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import java.lang.Exception
 import javax.inject.Inject
 
 @HiltViewModel
@@ -51,18 +49,19 @@ class FriendInformationViewModel @Inject constructor(
         }
     }
 
-    fun updateFriend(friend: FriendUiModel) {
+    fun updateFriend(newFriend: FriendUiModel) {
         viewModelScope.launch {
             val param = UpdateFriendParams(
-                name = friend.name ?: throw Exception("name shouldn't be null"),
-                groupId = friend.group?.groupId ?: throw Exception("groupId shouldn't be null"),
-                dateOfBirth = friend.birthday ?: throw Exception("birthday shouldn't be null"),
-                thumbnailImageUrl = friend.profileUrl,
-                kakaoId = friend.kakaoId
+                name = newFriend.name ?: throw Exception("name shouldn't be null"),
+                groupId = newFriend.group?.groupId ?: throw Exception("groupId shouldn't be null"),
+                dateOfBirth = newFriend.birthday ?: throw Exception("birthday shouldn't be null"),
+                thumbnailImageUrl = newFriend.profileUrl,
+                kakaoId = newFriend.kakaoId
             )
-            val result = updateFriendUseCase(param)
-
-            _friendId.postValue(result)
+            friend?.id?.let {
+                val result = updateFriendUseCase(it, param)
+                _friendId.postValue(result)
+            }
         }
     }
 }

--- a/presenter/src/main/java/com/mashup/chinchin/presenter/main/MainActivity.kt
+++ b/presenter/src/main/java/com/mashup/chinchin/presenter/main/MainActivity.kt
@@ -95,7 +95,7 @@ class MainActivity : ComponentActivity() {
 
     private fun initRecommendFriends(): List<FriendUiModel> {
         return List(25) {
-            FriendUiModel(0, "안경무 $it", "https://picsum.photos/200", null) // 수정 후 삭제 부탁합니다.
+            FriendUiModel(0, "안경무 $it", group = null, birthday = null, profileUrl = "https://picsum.photos/200") // 수정 후 삭제 부탁합니다.
         }
     }
 }

--- a/presenter/src/main/java/com/mashup/chinchin/presenter/ui/common/ChinChinComponent.kt
+++ b/presenter/src/main/java/com/mashup/chinchin/presenter/ui/common/ChinChinComponent.kt
@@ -537,7 +537,6 @@ fun ChinChinFriendCard(
                 modifier = Modifier
                     .size(54.dp)
                     .clip(CircleShape),
-
                 error = painterResource(R.drawable.profile_default_image),
                 placeholder = painterResource(R.drawable.profile_default_image),
             )

--- a/presenter/src/main/java/com/mashup/chinchin/presenter/ui/main/home/HomeComponent.kt
+++ b/presenter/src/main/java/com/mashup/chinchin/presenter/ui/main/home/HomeComponent.kt
@@ -52,7 +52,9 @@ fun EmptyFriendGroups() {
         Image(
             painter = painterResource(id = R.drawable.img_empty_group),
             contentDescription = "",
-            modifier = Modifier.padding(top = 90.dp).size(200.dp)
+            modifier = Modifier
+                .padding(top = 90.dp)
+                .size(200.dp)
         )
     }
 }
@@ -219,7 +221,7 @@ fun FriendGroupCard(
         ) {
             FriendGroupCardTitle(groupInfo.groupName)
             NumberOfFriends(groupInfo.groupMemberCount)
-            FriendProfileThumbnailList(groupInfo.thumbnailImageUrls)
+            FriendProfileThumbnailList(groupInfo.groupMemberCount, groupInfo.thumbnailImageUrls)
         }
     }
 }
@@ -259,32 +261,35 @@ fun NumberOfFriends(friendsSize: Int) {
 }
 
 @Composable
-fun FriendProfileThumbnailList(thumbnailUrls: List<String>) {
-    val profileMoreCount = if (thumbnailUrls.size > 5) {
-        thumbnailUrls.size - 5
+fun FriendProfileThumbnailList(groupCount: Int, thumbnailUrls: List<String?>) {
+    val profileMoreCount = if (groupCount > 5) {
+        groupCount - 5
     } else {
         0
     }
-
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 18.dp, vertical = 16.dp)
-    ) {
-        run loop@{
-            thumbnailUrls.forEachIndexed { index, thumbnailUrl ->
-                val start = (27 * index).dp
-                if (index < 5) {
-                    FriendProfileThumbnail(
-                        thumbnailUrl = thumbnailUrl,
-                        modifier = Modifier.padding(start = start),
-                    )
-                } else {
-                    FriendProfileThumbnailMore(
-                        moreSize = profileMoreCount,
-                        Modifier.padding(start = start),
-                    )
-                    return@forEachIndexed
+    if (groupCount == 0) {
+        FriendZeroThumbnail()
+    } else {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 18.dp, vertical = 16.dp)
+        ) {
+            run loop@{
+                thumbnailUrls.forEachIndexed { index, thumbnailUrl ->
+                    val start = (27 * index).dp
+                    if (index < 5) {
+                        FriendProfileThumbnail(
+                            thumbnailUrl = thumbnailUrl,
+                            modifier = Modifier.padding(start = start),
+                        )
+                    } else {
+                        FriendProfileThumbnailWhiteCircle(
+                            size = profileMoreCount,
+                            Modifier.padding(start = start),
+                        )
+                        return@forEachIndexed
+                    }
                 }
             }
         }
@@ -292,15 +297,29 @@ fun FriendProfileThumbnailList(thumbnailUrls: List<String>) {
 }
 
 @Composable
-fun FriendProfileThumbnailMore(moreSize: Int, modifier: Modifier = Modifier) {
+fun FriendZeroThumbnail() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 18.dp, vertical = 16.dp)
+    ) {
+        FriendProfileThumbnailWhiteCircle(
+            size = 0,
+        )
+    }
+}
+
+@Composable
+fun FriendProfileThumbnailWhiteCircle(size: Int, modifier: Modifier = Modifier) {
     Card(
         shape = CircleShape,
         modifier = modifier
             .height(36.dp)
             .width(36.dp),
+        elevation = 0.dp
     ) {
         Text(
-            text = "+${moreSize}",
+            text = if (size > 0) "+${size}" else "$size",
             fontSize = 14.sp,
             fontWeight = FontWeight.Bold,
             modifier = Modifier.wrapContentSize(Alignment.Center)
@@ -309,7 +328,7 @@ fun FriendProfileThumbnailMore(moreSize: Int, modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun FriendProfileThumbnail(thumbnailUrl: String, modifier: Modifier = Modifier) {
+fun FriendProfileThumbnail(thumbnailUrl: String?, modifier: Modifier = Modifier) {
     AsyncImage(
         model = thumbnailUrl,
         contentDescription = "friendProfile",
@@ -317,7 +336,9 @@ fun FriendProfileThumbnail(thumbnailUrl: String, modifier: Modifier = Modifier) 
         modifier = modifier
             .size(36.dp)
             .clip(CircleShape)
-            .border(2.dp, Secondary_1, CircleShape)
+            .border(2.dp, Secondary_1, CircleShape),
+        error = painterResource(R.drawable.profile_default_image),
+        placeholder = painterResource(R.drawable.profile_default_image),
     )
 }
 


### PR DESCRIPTION
메인 썸네일 이미지 안나오는 이슈 및 친구 프로필 화면 groupName 대응

_프로필이 null인 애들은 지금 아예 내려주질 않아서 다른 카드들은 아예 썸네일이 안보이는데,
백엔드에서 null로 내려주면 에러로 떨어져서 친친바라로 보일 거에요~_