### PR TITLE
#175 친구 카드의 화살표 아이콘을 옵셔너블하게 사용할 수 있도록 수정

### DIFF
--- a/presenter/src/main/java/com/mashup/chinchin/presenter/ui/common/ChinChinComponent.kt
+++ b/presenter/src/main/java/com/mashup/chinchin/presenter/ui/common/ChinChinComponent.kt
@@ -574,6 +574,7 @@ fun ChinChinGrayTextField(
 fun ChinChinFriendCard(
     modifier: Modifier = Modifier,
     friend: FriendUiModel?,
+    isShowArrowIcon: Boolean = false,
     onClickCard: () -> Unit = {},
 ) {
     Card(
@@ -585,7 +586,7 @@ fun ChinChinFriendCard(
         backgroundColor = Secondary_1
     ) {
         Row(
-            modifier = Modifier.padding(start = 16.dp),
+            modifier = Modifier.padding(horizontal = 16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             AsyncImage(
@@ -598,11 +599,11 @@ fun ChinChinFriendCard(
                 error = painterResource(R.drawable.profile_default_image),
                 placeholder = painterResource(R.drawable.profile_default_image),
             )
-            Box(
+            Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 12.dp),
-                contentAlignment = Alignment.CenterStart,
+                    .padding(start = 12.dp),
+                horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 Text(
                     text = friend?.name ?: "",
@@ -610,6 +611,13 @@ fun ChinChinFriendCard(
                     color = Black,
                     fontSize = 16.sp,
                 )
+
+                if (isShowArrowIcon) {
+                    Image(
+                        painter = painterResource(id = R.drawable.ic_right_arrow),
+                        contentDescription = ""
+                    )
+                }
             }
         }
 

--- a/presenter/src/main/java/com/mashup/chinchin/presenter/ui/group_detail/GroupDetailComponent.kt
+++ b/presenter/src/main/java/com/mashup/chinchin/presenter/ui/group_detail/GroupDetailComponent.kt
@@ -30,6 +30,7 @@ fun GroupDetailList(
                     .height(78.dp)
                     .padding(horizontal = 24.dp),
                 friend = friend,
+                isShowArrowIcon = true,
                 onClickCard = { onClickCard(friend) }
             )
         }


### PR DESCRIPTION
공통 친구 카드 우측에 아이콘을 옵셔너블하게 켜고 끌 수 있도록 수정해두었습니다.

친구 리스트에서 볼 때는 화살표가 있고, 기존 친구 목록(ConnectFriends)에서 보면 화살표가 없기때문에 구분해서 사용할 수 있도록 isShowArrowIcon 옵션을 만들어두었어요~